### PR TITLE
Add placeholder and better error message for birthday field

### DIFF
--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -72,15 +72,17 @@ class ApplicationForm(FlaskForm):
 
     # First and last name are redundant with an associated user - preferred name could be useful
     preferred_name = StringField("Preferred Name", validators=[DataRequired()])
+
     birthday = DateField(
         "Birthday",
         validators=[
-            DataRequired(),
+            DataRequired(message="Required, must be in YYYY-MM-DD format"),
             OldestAllowedDate(
                 datetime.date(2020 - 18, 2, 15),
                 message="You must be 18 on Fubruary 15, 2020 to participate in MakeUofT.",
             ),
         ],
+        render_kw={"placeholder": "YYYY-MM-DD"},
     )
 
     gender = SelectField(


### PR DESCRIPTION
On Safari for macOS, date fields do not work. This adds placeholder text, and changes the error message to be more descriptive.

Note that when the date format is incorrect, the form sees the fields as empty. For some reason, `ApplicationForm.birthday.process_errors` is not being appended to `ApplicationForm.birthday.errors`, and so notification about invalid format was not being made. This relates to this issue: https://github.com/wtforms/wtforms/issues/435